### PR TITLE
feat(t8030): add memory-backend support

### DIFF
--- a/hw/arm/apple-silicon/t8030.c
+++ b/hw/arm/apple-silicon/t8030.c
@@ -2721,9 +2721,17 @@ static void t8030_machine_init(MachineState *machine)
                  T8030_SROM_SIZE, 0);
     allocate_ram(t8030_machine->sys_mem, "SRAM", T8030_SRAM_BASE,
                  T8030_SRAM_SIZE, 0);
-    t8030_machine->dram =
-        allocate_ram(t8030_machine->sys_mem, "DRAM", T8030_DRAM_BASE,
-                     machine->maxram_size, 0);
+    if (machine->memdev != NULL) {
+        t8030_machine->dram = host_memory_backend_get_memory(machine->memdev);
+        memory_region_add_subregion_overlap(t8030_machine->sys_mem,
+                                            T8030_DRAM_BASE,
+                                            t8030_machine->dram,
+                                            0);
+    } else {
+        t8030_machine->dram =
+            allocate_ram(t8030_machine->sys_mem, "DRAM", T8030_DRAM_BASE,
+                         machine->maxram_size, 0);
+    }
     if (t8030_machine->sep_rom_filename != NULL) {
         allocate_ram(t8030_machine->sys_mem, "SEPROM", T8030_SEPROM_BASE,
                      T8030_SEPROM_SIZE, 0);


### PR DESCRIPTION
The T8030 machine now honors `-machine memory-backend=<id>`, so DRAM can be backed by a file, shared memory, etc.